### PR TITLE
Workaround USB stack freeze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.map
 *.o
 test_blaster
+/*.sym

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ OBJCOPY ?= $(VBCC)/bin/m68k-amigaos-objcopy
 CFLAGS := -O2 -g -noixemul -m68020 -mregparm=4 -fomit-frame-pointer -DPLAYSID
 
 SOURCE   := playsid.asm
-INCLUDES := playsid_libdefs.i
+INCLUDES := playsid_libdefs.i external.asm resid-68k/resid-68k.s resid-68k/resid-68k.i
 
 TARGET   := playsid.library test_blaster
 LISTFILE := playsid.txt
@@ -22,7 +22,7 @@ all: $(TARGET)
 clean:
 	rm -f $(TARGET) $(LISTFILE) playsid.map test_blaster.map *.o *.sym
 
-playsid.o: playsid.asm playsid_libdefs.i external.asm Makefile
+playsid.o: playsid.asm $(INCLUDES) Makefile
 	$(VASM) $< -o $@ -L $(LISTFILE) $(VASM_FLAGS) -Iresid-68k
 	$(OBJCOPY) --rename-section reSID_data=.data $@
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VASM_FLAGS := -Fhunk -kick1hunks -quiet -m68060 -nosym -showcrit -I $(VBCC)/m68k
 
 GCC ?= $(VBCC)/bin/m68k-amigaos-gcc
 STRIP ?= $(VBCC)/bin/m68k-amigaos-strip
-CFLAGS := -O2 -g -noixemul -m68020 --omit-frame-pointer -DPLAYSID
+CFLAGS := -O2 -g -noixemul -m68020 -mregparm=4 -fomit-frame-pointer -DPLAYSID
 
 SOURCE   = playsid.asm 
 INCLUDES := playsid_libdefs.i 
@@ -23,8 +23,8 @@ clean:
 playsid.o: playsid.asm playsid_libdefs.i external.asm Makefile
 	$(VASM) $< -o $@ -L $(LISTFILE) $(VASM_FLAGS) -Iresid-68k
 
-sidblast.o: sidblast.c | Makefile
-	$(GCC) -c $< -o $@ -L $(CFLAGS)
+sidblast.o: sidblast.c Makefile
+	$(GCC) -c $< -o $@ $(CFLAGS)
 
 playsid.library: playsid.o sidblast.o | Makefile
 	$(GCC) -m68020 -nostdlib -g -Wl,-Map,playsid.map,--cref $^ -o $@

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ VASM_FLAGS := -Fhunk -kick1hunks -quiet -m68060 -nosym -showcrit -I $(VBCC)/m68k
 
 GCC ?= $(VBCC)/bin/m68k-amigaos-gcc
 STRIP ?= $(VBCC)/bin/m68k-amigaos-strip
+OBJCOPY ?= $(VBCC)/bin/m68k-amigaos-objcopy
 
 CFLAGS := -O2 -g -noixemul -m68020 -mregparm=4 -fomit-frame-pointer -DPLAYSID
 
@@ -23,6 +24,7 @@ clean:
 
 playsid.o: playsid.asm playsid_libdefs.i external.asm Makefile
 	$(VASM) $< -o $@ -L $(LISTFILE) $(VASM_FLAGS) -Iresid-68k
+	$(OBJCOPY) --rename-section reSID_data=.data $@
 
 sidblast.o: sidblast.c Makefile
 	$(GCC) -c $< -o $@ $(CFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VASM_FLAGS := -Fhunk -kick1hunks -quiet -m68060 -nosym -showcrit -I $(VBCC)/m68k
 
 GCC ?= $(VBCC)/bin/m68k-amigaos-gcc
 STRIP ?= $(VBCC)/bin/m68k-amigaos-strip
-CFLAGS := -O2 -g -noixemul -m68060 --omit-frame-pointer -DPLAYSID
+CFLAGS := -O2 -g -noixemul -m68020 --omit-frame-pointer -DPLAYSID
 
 SOURCE   = playsid.asm 
 INCLUDES := playsid_libdefs.i 
@@ -27,8 +27,8 @@ sidblast.o: sidblast.c | Makefile
 	$(GCC) -c $< -o $@ -L $(CFLAGS)
 
 playsid.library: playsid.o sidblast.o | Makefile
-	$(GCC) -m68060 -nostdlib -g -Wl,-Map,playsid.map,--cref $^ -o $@
+	$(GCC) -m68020 -nostdlib -g -Wl,-Map,playsid.map,--cref $^ -o $@
 	$(STRIP) $@
 
 test_blaster: test_blaster.c sidblast.c
-	$(GCC) -O2 -g -noixemul -m68060 --omit-frame-pointer -Wl,-Map,test_blaster.map,--cref $^ -o $@
+	$(GCC) -O2 -g -noixemul -m68020 --omit-frame-pointer -Wl,-Map,test_blaster.map,--cref $^ -o $@

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,11 @@ VASM_FLAGS := -Fhunk -kick1hunks -quiet -m68060 -nosym -showcrit -I $(VBCC)/m68k
 
 GCC ?= $(VBCC)/bin/m68k-amigaos-gcc
 STRIP ?= $(VBCC)/bin/m68k-amigaos-strip
+
 CFLAGS := -O2 -g -noixemul -m68020 -mregparm=4 -fomit-frame-pointer -DPLAYSID
 
-SOURCE   = playsid.asm 
-INCLUDES := playsid_libdefs.i 
+SOURCE   := playsid.asm
+INCLUDES := playsid_libdefs.i
 
 TARGET   := playsid.library test_blaster
 LISTFILE := playsid.txt
@@ -18,7 +19,7 @@ LISTFILE := playsid.txt
 all: $(TARGET)
 
 clean:
-	rm -f $(TARGET) $(LISTFILE) playsid.map test_blaster.map *.o
+	rm -f $(TARGET) $(LISTFILE) playsid.map test_blaster.map *.o *.sym
 
 playsid.o: playsid.asm playsid_libdefs.i external.asm Makefile
 	$(VASM) $< -o $@ -L $(LISTFILE) $(VASM_FLAGS) -Iresid-68k
@@ -26,9 +27,11 @@ playsid.o: playsid.asm playsid_libdefs.i external.asm Makefile
 sidblast.o: sidblast.c Makefile
 	$(GCC) -c $< -o $@ $(CFLAGS)
 
-playsid.library: playsid.o sidblast.o | Makefile
+playsid.library.sym: playsid.o sidblast.o | Makefile
 	$(GCC) -m68020 -nostdlib -g -Wl,-Map,playsid.map,--cref $^ -o $@
-	$(STRIP) $@
+
+playsid.library: playsid.library.sym
+	$(STRIP) $^ -o $@
 
 test_blaster: test_blaster.c sidblast.c
 	$(GCC) -O2 -g -noixemul -m68020 --omit-frame-pointer -Wl,-Map,test_blaster.map,--cref $^ -o $@

--- a/external.asm
+++ b/external.asm
@@ -1,4 +1,4 @@
-	section EXTDATA,data_p
+	section .data,data_p
 
 DAT_002273d4
 	dc.b	$00,$20,$20,$20,$20,$20,$20,$20,$20,$20,$28,$28,$28,$28,$28,$20
@@ -22,7 +22,7 @@ DAT_002273d4
 DAT_002273d0
 	dc.l $00000000
 
-	section EXTCODE,code_p
+	section .text,code_p
 
 @AllocEmulAudio_impl
      subq.w     #$4,sp

--- a/playsid.asm
+++ b/playsid.asm
@@ -136,7 +136,7 @@ SPRINT  macro
 		xref	_custom,_ciaa,_ciab
 		xref	@AllocEmulAudio,@FreeEmulAudio,@ReadIcon
 
-		xref	_sid_init,_sid_exit,_sid_write_reg
+		xref	_sid_init,_sid_exit,_sid_write_reg_record,_sid_write_reg_playback
 
                 xdef    _PlaySidBase
 *=======================================================================*
@@ -967,6 +967,10 @@ Play64:
 		bsr	    ReadDisplayData
 		bsr	    DisplayRequest
 .1
+        cmp.w   #OM_SIDBLASTER_USB,psb_OperatingMode(a6)
+        bne.b	.2
+		bsr	flush_sid_regs
+.2
 		bsr	CalcTime
 		bsr	CheckC64TimerA
 
@@ -4652,18 +4656,6 @@ writeSID2Register:
 
 *-----------------------------------------------------------------------*
 
-
-write_sid_reg:
-	movem.l	d0-a6,-(sp)
-	and.l	#$ff,d7
-	and.l	#$ff,d6
-	move.l	d7,d0
-	move.l	d6,d1
-	jsr	_sid_write_reg
-    moveq   #1,d0
-	movem.l	(sp)+,d0-a6
-	rts
-
 start_sid_blaster:
     DPRINT  "start_sid_blaster"
 	movem.l	d1-a6,-(sp)
@@ -4683,6 +4675,22 @@ stop_sid_blaster:
     DPRINT  "stop_sid_blaster"
 	movem.l	d0-a6,-(sp)
 	jsr	_sid_exit
+	movem.l	(sp)+,d0-a6
+	rts
+
+write_sid_reg:
+	movem.l	d0-a6,-(sp)
+	and.l	#$ff,d7
+	and.l	#$ff,d6
+	move.l	d7,d0
+	move.l	d6,d1
+	jsr	_sid_write_reg_record
+	movem.l	(sp)+,d0-a6
+	rts
+
+flush_sid_regs:
+	movem.l	d0-a6,-(sp)		; paranoia
+	jsr	_sid_write_reg_playback
 	movem.l	(sp)+,d0-a6
 	rts
 

--- a/playsid.asm
+++ b/playsid.asm
@@ -4667,6 +4667,8 @@ write_sid_reg:
 start_sid_blaster:
     DPRINT  "start_sid_blaster"
 	movem.l	d1-a6,-(sp)
+	moveq.l	#$10,d0	; latency
+	moveq.l	#$5,d1	; taskpri
 	jsr	_sid_init
 	tst.l	d0
 	bne.b	.ok

--- a/playsid.asm
+++ b/playsid.asm
@@ -144,7 +144,7 @@ SPRINT  macro
 *	CODE SECTION							*
 *									*
 *=======================================================================*
-		section	EmulSID_library,CODE
+		section	.text,CODE
 *-----------------------------------------------------------------------*
 
 *=======================================================================*
@@ -5446,7 +5446,7 @@ EndOfLibrary
 *	DATA SECTION							*
 *                                                                       *
 *=======================================================================*
-	Section	DATA,data
+	Section	.data,data
 *-----------------------------------------------------------------------*
 
 *=======================================================================*
@@ -7938,7 +7938,7 @@ IEND
 *	BSS SECTION							*
 *									*
 *=======================================================================*
-	section	BSS,bss
+	section	.bss,bss
 *-----------------------------------------------------------------------*
 VolumeTable	ds.l	($1000)/4
 Enve1		ds.l	(env_SIZEOF+3)/4
@@ -7972,7 +7972,7 @@ residData2     ds.b    resid_SIZEOF
 *
 *-----------------------------------------------------------------------*
 
-        section    reSID1,code
+        section    .text,code
 
   ifd __VASM
     ; Turn on optimization for reSID
@@ -7984,7 +7984,7 @@ residData2     ds.b    resid_SIZEOF
 
         include resid-68k.s
 
-        section    reSID2,code
+        section    .text,code
 
 
 @SetVolume 
@@ -9510,7 +9510,7 @@ plainSaveFile:
 	rts
   endif
 
-    section bss1,bss
+    section .bss,bss
 
 workerTaskStack     ds.b    4096
 workerTaskStruct    ds.b    TC_SIZE

--- a/sidblast.c
+++ b/sidblast.c
@@ -1,10 +1,11 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
 #include <proto/exec.h>
 #include <proto/poseidon.h>
 #include <exec/alerts.h>
-#include <stdint.h>
-#include <stdarg.h>
+#include <utility/hooks.h>
 
 #include "sidblast.h"
 
@@ -46,7 +47,8 @@ static void SIDTask();
 static void writePacket(uint8_t* packet, uint16_t length);
 static uint8_t readResult();
 static uint32_t deviceUnplugged(register struct Hook *hook __asm("a0"), register APTR object __asm("a2"), register APTR message __asm("a1"));
-static const struct Hook hook = { .h_Entry = (HOOKFUNC)deviceUnplugged };
+typedef ULONG (*HOOKFUNC_ULONG)();  // NDK typedef HOOKFUNC with 'unsigned long'
+static const struct Hook hook = { .h_Entry = (HOOKFUNC_ULONG)deviceUnplugged };
 
 #ifdef DEBUG
 

--- a/sidblast.h
+++ b/sidblast.h
@@ -4,3 +4,5 @@ uint8_t sid_init(register uint8_t latency __asm("d0"), register int8_t taskpri _
 void    sid_exit();
 uint8_t sid_read_reg(register uint8_t reg __asm("d0"));
 void    sid_write_reg(register uint8_t reg __asm("d0"), register uint8_t value __asm("d1"));
+void    sid_write_reg_record(register uint8_t reg __asm("d0"), register uint8_t value __asm("d1"));
+void    sid_write_reg_playback();

--- a/sidblast.h
+++ b/sidblast.h
@@ -1,6 +1,6 @@
 #pragma once
 
-uint8_t sid_init();
+uint8_t sid_init(register uint8_t latency __asm("d0"), register int8_t taskpri __asm("d1"));
 void    sid_exit();
 uint8_t sid_read_reg(register uint8_t reg __asm("d0"));
 void    sid_write_reg(register uint8_t reg __asm("d0"), register uint8_t value __asm("d1"));

--- a/test_blaster.c
+++ b/test_blaster.c
@@ -8,7 +8,7 @@
 
 int main()
 {
-    if (!sid_init())
+    if (!sid_init(16, 0))
     {
         printf("sid init failed\n");
         return -1;

--- a/test_blaster.c
+++ b/test_blaster.c
@@ -1,14 +1,46 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <proto/exec.h>
+#include <proto/timer.h>
 #include <proto/poseidon.h>
 #include <string.h>
 
 #include "sidblast.h"
 
-int main()
+uint32_t timeout = 10;  // seconds
+uint32_t latency = 16;  // milliseconds
+int32_t  taskpri = 20;  // exec task priority (-128 .. 127)
+
+struct Device* TimerBase;
+
+int main(int argc, const char** argv)
 {
-    if (!sid_init(16, 0))
+    if (argc > 1)
+        timeout = strtol(argv[1], 0, 10);
+    if (argc > 2)
+        latency = strtol(argv[2], 0, 10);
+    if (argc > 3)
+        taskpri = strtol(argv[3], 0, 10);
+
+    printf("%s <timeout:%d> <latency:%d> <taskpri:%d>\n", argv[0], timeout, latency, taskpri);
+
+    if (timeout > 1000)
+    {
+        printf("timeout > 1000 doesn't make much sense\n");
+        return FALSE;
+    }
+    else if (latency > 255)
+    {
+        printf("latency > 255 is not possible\n");
+        return FALSE;
+    }
+    else if (taskpri > 127 || taskpri <-128)
+    {
+        printf("taskpri is [-128,127]\n");
+        return FALSE;
+    }
+
+    if (!sid_init(latency, taskpri))
     {
         printf("sid init failed\n");
         return -1;
@@ -21,34 +53,106 @@ int main()
         return FALSE;
     }
 
-    sid_write_reg(0x18, 0x0f);
-    sid_read_reg(0x18);
-
+    struct MsgPort timerPort = { 0 };
+    struct timerequest timerRequest = { 0 };
+    timerRequest.tr_node.io_Message.mn_ReplyPort = &timerPort;
+    if (OpenDevice(TIMERNAME, UNIT_VBLANK, &timerRequest.tr_node, 0))
     {
-        sid_write_reg(0x00, 0x00);
-        sid_write_reg(0x01, 0x00);
-        sid_write_reg(0x07, 0x00);
-        sid_write_reg(0x08, 0x00);
-        sid_write_reg(0x0e, 0x00);
-        sid_write_reg(0x0f, 0x00);
-
-        uint8_t readbuf[3];
-        for (int i = 0; i < 50; ++i)
-        {
-            psdDelayMS(20);
-
-            sid_write_reg(0x18, 0x0f);
-            uint8_t v = sid_read_reg(0x18);
-            printf("$18 = %02lx\n", v);
-
-            psdDelayMS(1);
-
-            sid_write_reg(0x18, 0x00);
-            v = sid_read_reg(0x18);
-            printf("$18 = %02lx\n", v);
-
-        }
+        printf("OpenDevice(\"%s\") failed\n", TIMERNAME);
+        CloseLibrary(PsdBase);
+        return FALSE;
     }
+
+    TimerBase = (struct Device*)timerRequest.tr_node.io_Device;
+
+    struct timeval startTime, currentTime;
+
+    GetSysTime(&startTime);
+
+    for (int i = 0x00; i <= 0x18; ++i)
+        sid_write_reg(i, 0x00);
+
+    // voice 1
+    sid_write_reg(0x00, 0x04);      // freq lo
+    sid_write_reg(0x01, 0x04);      // freq hi
+    sid_write_reg(0x02, 0xff);      // pulse width lo
+    sid_write_reg(0x03, 0x07);      // pulse width hi
+    sid_write_reg(0x05, 0x00);      // attack  | decay
+    sid_write_reg(0x06, 0xf0);      // sustain | release
+
+    // voice 2
+    sid_write_reg(0x00+7, 0x10);    // freq lo
+    sid_write_reg(0x01+7, 0x04);    // freq hi
+    sid_write_reg(0x02+7, 0xff);    // pulse width lo
+    sid_write_reg(0x03+7, 0x07);    // pulse width hi
+    sid_write_reg(0x05+7, 0x00);    // attack  | decay
+    sid_write_reg(0x06+7, 0xf0);    // sustain | release
+
+    // voice 3
+    sid_write_reg(0x00+7*2, 0x0a);  // freq lo
+    sid_write_reg(0x01+7*2, 0x00);  // freq hi
+    sid_write_reg(0x02+7*2, 0xff);  // pulse width lo
+    sid_write_reg(0x03+7*2, 0x07);  // pulse width hi
+    sid_write_reg(0x05+7*2, 0x00);  // attack  | decay
+    sid_write_reg(0x06+7*2, 0xf0);  // sustain | release
+
+    sid_write_reg(0x15, 0x00);      // filter cut-off lo
+    sid_write_reg(0x16, 0x00);      // filter cut-off hi
+
+    sid_write_reg(0x17, 0x83);      // resonance   | filter control
+    sid_write_reg(0x18, 0x1f);      // filter mode | volume 
+
+    printf("sweeping...\n"); fflush(stdout);
+
+    // gate 1+2+3
+    sid_write_reg(0x04, 0x41);      // square | gate
+    sid_write_reg(0x04+7, 0x41);    // square | gate
+    sid_write_reg(0x04+7*2, 0x11);  // triang | gate
+
+    while(1)
+    {
+        GetSysTime(&currentTime);
+        SubTime(&currentTime, &startTime);
+
+        if (currentTime.tv_secs >= timeout)
+            break;
+
+        printf("time = %d.%d ; ", currentTime.tv_secs, currentTime.tv_micro);
+
+        psdDelayMS(20);
+
+        // read voice 3 oscillator and use it to sweep the filter cut-off
+        uint8_t voice3osc = sid_read_reg(0x1b);
+
+        uint8_t cutoff_lo = voice3osc & 0xf;
+        uint8_t cutoff_hi = voice3osc >> 3;
+
+        sid_write_reg(0x15, cutoff_lo);
+        sid_write_reg(0x16, cutoff_hi);
+
+        // use time as input to the pulse width phasing
+        uint16_t phase = (currentTime.tv_secs << 8) | (currentTime.tv_micro >> 12);
+
+        uint8_t phase_lo = phase & 0xff;
+        uint8_t phase_hi = phase >> 8;
+
+        sid_write_reg(0x02, phase_lo);
+        sid_write_reg(0x03, phase_hi);
+
+        phase += 0xff;        // offset voice 1 phase slightly
+        phase_lo = phase & 0xff;
+        phase_hi = phase >> 8;
+
+        sid_write_reg(0x02+7, phase_lo);
+        sid_write_reg(0x03+7, phase_hi);
+
+        printf("\n"); fflush(stdout);
+    }
+
+    // reset all registers
+    for (int i = 0x00; i <= 0x18; ++i)
+        sid_write_reg(i, 0x00);
+
     CloseLibrary(PsdBase);
 
     sid_exit();

--- a/test_blaster.c
+++ b/test_blaster.c
@@ -70,7 +70,8 @@ int main(int argc, const char** argv)
     GetSysTime(&startTime);
 
     for (int i = 0x00; i <= 0x18; ++i)
-        sid_write_reg(i, 0x00);
+        sid_write_reg_record(i, 0x00);
+    sid_write_reg_playback();
 
     // voice 1
     sid_write_reg(0x00, 0x04);      // freq lo
@@ -105,9 +106,10 @@ int main(int argc, const char** argv)
     printf("sweeping...\n"); fflush(stdout);
 
     // gate 1+2+3
-    sid_write_reg(0x04, 0x41);      // square | gate
-    sid_write_reg(0x04+7, 0x41);    // square | gate
-    sid_write_reg(0x04+7*2, 0x11);  // triang | gate
+    sid_write_reg_record(0x04, 0x41);      // square | gate
+    sid_write_reg_record(0x04+7, 0x41);    // square | gate
+    sid_write_reg_record(0x04+7*2, 0x11);  // triang | gate
+    sid_write_reg_playback();
 
     while(1)
     {
@@ -124,11 +126,13 @@ int main(int argc, const char** argv)
         // read voice 3 oscillator and use it to sweep the filter cut-off
         uint8_t voice3osc = sid_read_reg(0x1b);
 
+        printf("voice3osc %2x", voice3osc);
+
         uint8_t cutoff_lo = voice3osc & 0xf;
         uint8_t cutoff_hi = voice3osc >> 3;
 
-        sid_write_reg(0x15, cutoff_lo);
-        sid_write_reg(0x16, cutoff_hi);
+        sid_write_reg_record(0x15, cutoff_lo);
+        sid_write_reg_record(0x16, cutoff_hi);
 
         // use time as input to the pulse width phasing
         uint16_t phase = (currentTime.tv_secs << 8) | (currentTime.tv_micro >> 12);
@@ -136,22 +140,25 @@ int main(int argc, const char** argv)
         uint8_t phase_lo = phase & 0xff;
         uint8_t phase_hi = phase >> 8;
 
-        sid_write_reg(0x02, phase_lo);
-        sid_write_reg(0x03, phase_hi);
+        sid_write_reg_record(0x02, phase_lo);
+        sid_write_reg_record(0x03, phase_hi);
 
         phase += 0xff;        // offset voice 1 phase slightly
         phase_lo = phase & 0xff;
         phase_hi = phase >> 8;
 
-        sid_write_reg(0x02+7, phase_lo);
-        sid_write_reg(0x03+7, phase_hi);
+        sid_write_reg_record(0x02+7, phase_lo);
+        sid_write_reg_record(0x03+7, phase_hi);
+
+        sid_write_reg_playback();
 
         printf("\n"); fflush(stdout);
     }
 
     // reset all registers
     for (int i = 0x00; i <= 0x18; ++i)
-        sid_write_reg(i, 0x00);
+        sid_write_reg_record(i, 0x00);
+    sid_write_reg_playback();
 
     CloseLibrary(PsdBase);
 


### PR DESCRIPTION
- Fix occasional lock-up in the Poseidon USB stack, by only opening INPIPE requests when doing SID register reads. 
- Batch SID register writes per PlaySID emulation "frame", to improve performance.
- Optimize `writePacket()` by adding an early-out if the store buffer is full, and inline the `Enable()`/`CopyMem()`/`Disable()`.
- Change optimization target to 68020, to improve performance on architectures that are the most limited (020/030).
- Merge hunks/sections in `playsid.library`.