### PR TITLE
Fix crash on KS1.3

### DIFF
--- a/external.asm
+++ b/external.asm
@@ -31,33 +31,33 @@ DAT_002273d0
      lea        ($7,sp),a1
      move.b     (a0)+,(a1)+
      movea.l    ($4).w,a6
-     jsr        (-$29a,a6)
+     jsr        (-$29a,a6)              ; _LVOCreateMsgPort
      movea.l    (_PlaySidBase).l,a0
-     move.l     d0,($16c,a0)
+     move.l     d0,($16c,a0)            ; psb_AudioMP
      beq.b      LAB_0022755c
-     moveq      #$44,d0
-     move.l     #$10001,d1
-     jsr        (-$c6,a6)
+     moveq      #$44,d0                 ; ioa_SIZEOF
+     move.l     #$10001,d1              ; MEMF_PUBLIC!MEMF_CLEAR
+     jsr        (-$c6,a6)               ; _LVOAllocMem
      tst.l      d0
      beq.b      LAB_0022755c
      movea.l    (_PlaySidBase).l,a0
-     move.l     d0,($168,a0)
+     move.l     d0,($168,a0)            ; psb_AudioIO
      movea.l    d0,a1
-     move.l     ($16c,a0),($e,a1)
-     move.b     #$7f,($9,a1)
-     clr.w      ($20,a1)
+     move.l     ($16c,a0),($e,a1)       ; psb_AudioMP,MN_REPLYPORT
+     move.b     #$7f,($9,a1)            ; LN_PRI
+     clr.w      ($20,a1)                ; ioa_AllocKey
      lea        ($7,sp),a0
-     move.l     a0,($22,a1)
+     move.l     a0,($22,a1)             ; ioa_Data
      moveq      #$1,d1
-     move.l     d1,($26,a1)
+     move.l     d1,($26,a1)             ; ioa_Length
      moveq      #$0,d0
      move.l     d0,d1
      lea        (audio_device,pc),a0
-     jsr        (-$1bc,a6)
+     jsr        (-$1bc,a6)              ; _LVOOpenDevice
      move.b     d0,d1
      ext.w      d1
      movea.l    (_PlaySidBase).l,a0
-     move.w     d1,($166,a0)
+     move.w     d1,($166,a0)            ; psb_AudioDevice
      bne.b      LAB_0022755c
      moveq      #$0,d0
      bra.b      LAB_00227562
@@ -78,32 +78,32 @@ audio_device:
 @FreeEmulAudio_impl
     move.l     a6,-(sp)
     movea.l    (_PlaySidBase).l,a0
-    tst.w      ($166,a0)
+    tst.w      ($166,a0)                ; psb_AudioDevice
     bne.b      LAB_0022759e
-    movea.l    ($168,a0),a1
+    movea.l    ($168,a0),a1             ; psb_AudioIO
     movea.l    ($4).w,a6
-    jsr        (-$1c2,a6)
+    jsr        (-$1c2,a6)               ; _LVOCloseDevice
     movea.l    (_PlaySidBase).l,a0
-    move.w     #$1,($166,a0)
+    move.w     #$1,($166,a0)            ; psb_AudioDevice
 LAB_0022759e
     movea.l    (_PlaySidBase).l,a0
-    move.l     ($168,a0),d0
+    move.l     ($168,a0),d0             ; psb_AudioIO
     beq.b      LAB_002275c0
     movea.l    d0,a1
-    moveq      #$44,d0
+    moveq      #$44,d0                  ; ioa_SIZEOF
     movea.l    ($4).w,a6
-    jsr        (-$d2,a6)
+    jsr        (-$d2,a6)                ; _LVOFreeMem
     movea.l    (_PlaySidBase).l,a0
-    clr.l      ($168,a0)
+    clr.l      ($168,a0)                ; psb_AudioIO
 LAB_002275c0
     movea.l    (_PlaySidBase).l,a0
-    move.l     ($16c,a0),d0
+    move.l     ($16c,a0),d0             ; psb_AudioMP
     beq.b      LAB_002275e0
     movea.l    d0,a0
     movea.l    ($4).w,a6
-    jsr        (-$2a0,a6)
+    jsr        (-$2a0,a6)               ; _LVODeleteMsgPort
     movea.l    (_PlaySidBase).l,a0
-    clr.l      ($16c,a0)
+    clr.l      ($16c,a0)                ; psb_AudioMP
 LAB_002275e0
     movea.l    (sp)+,a6
     rts


### PR DESCRIPTION
Exec's `CreateMsgPort()` & `DeleteMsgPort()` are part of V36 (KS2.x+).
Instead create the message port manually.